### PR TITLE
Cleanup code formatting with clang and fix small issues.

### DIFF
--- a/src/libpreloadvaccine.c
+++ b/src/libpreloadvaccine.c
@@ -3,9 +3,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 /*
     From the rtld-audit manpage:
@@ -23,17 +23,13 @@
     version that is greater than that supported by the dynamic linker,
     then the audit library is ignored.
 */
-unsigned int la_version(unsigned int version)
-{
-    // Version == 0 means the library will be ignored by the linker.
-    if(version == 0)
-    {
-        return version;
-    }
-    else
-    {
-        return LAV_CURRENT;
-    }    
+unsigned int la_version(unsigned int version) {
+  // Version == 0 means the library will be ignored by the linker.
+  if (version == 0) {
+    return version;
+  } else {
+    return LAV_CURRENT;
+  }
 }
 
 /*
@@ -70,113 +66,93 @@ unsigned int la_version(unsigned int version)
     this audit library simply intends to monitor search paths, then name
     should be returned.
 */
-char *la_objsearch(const char *name, uintptr_t *cookie, unsigned int flag)
-{
-    // Don't really need these, discarding.
-    UNUSED(cookie);
-    UNUSED(flag);
+char *la_objsearch(const char *name, uintptr_t *cookie, unsigned int flag) {
+  // Don't really need these, discarding.
+  UNUSED(cookie);
+  UNUSED(flag);
 
-    // Determine if the object searched for is a preload and if it's whitelisted.
-    // If the preload is whitelisted (or if it isn't a preload), allow the load to proceed.
-    // If preload isn't whitelisted, return NULL to ignore the library search.
-    // Currently causes a ld.so error on the console when a preload is ignored.
-    if(is_preload(name) && (allowed_preload(name) == false))
-    {
-        return NULL;
-    }
-    else
-    {
-        return (char *)name;
-    }
+  // Determine if the object searched for is a preload and if it's whitelisted.
+  // If the preload is whitelisted (or if it isn't a preload), allow the load to
+  // proceed. If preload isn't whitelisted, return NULL to ignore the library
+  // search. Currently causes a ld.so error on the console when a preload is
+  // ignored.
+  if (is_preload(name) && (allowed_preload(name) == false)) {
+    return NULL;
+  } else {
+    return (char *)name;
+  }
 }
+
+const char *LD_PRELOAD_ENV_VAR = "LD_PRELOAD";
+const char *LD_SO_PRELOAD_PATH = "/etc/ld.so.preload";
+const char *LIB_PRELOAD_VACCINE_CONFIG_PATH = "/etc/libpreloadvaccine.allow";
 
 // Determine if the passed object is a preload.
 // Checks LD_PRELOAD environment variable and /etc/ld.so.preload
 // TODO: possibly check --preloads argument from the linker if possible
-bool is_preload(const char *object)
-{
-    bool in_ld_preload = env_variable_contains_object(object, "LD_PRELOAD");
-    bool in_ld_so_preload = file_contains_object(object, "/etc/ld.so.preload");
+bool is_preload(const char *object) {
+  bool in_ld_preload = env_variable_contains_object(object, LD_PRELOAD_ENV_VAR);
+  bool in_ld_so_preload = file_contains_object(object, LD_SO_PRELOAD_PATH);
 
-    // Return boolean
-    return (in_ld_preload || in_ld_so_preload);
+  // Return boolean
+  return (in_ld_preload || in_ld_so_preload);
 }
 
 // Determine if the passed object is whitelisted.
-bool allowed_preload(const char *object)
-{
-    return file_contains_object(object, "/etc/libpreloadvaccine.allow");
+bool allowed_preload(const char *object) {
+  return file_contains_object(object, LIB_PRELOAD_VACCINE_CONFIG_PATH);
 }
 
 // Determine if the passed object is within a specified environment variable.
-bool env_variable_contains_object (const char *object, const char *env_variable)
-{
-    bool contains_object;
+bool env_variable_contains_object(const char *object,
+                                  const char *env_variable) {
+  bool contains_object = false;
 
-    // Get the environment variable
-    const char *ld_preload = getenv(env_variable);
+  // Get the environment variable
+  const char *ld_preload = getenv(env_variable);
 
-    // If the variable doesn't exist, this NULL check will fail, continuing on.
-    if (ld_preload != NULL)
-    {
-        // Check if the returned environment variable string contains the object.
-        if (strstr(ld_preload,object) != NULL)
-        {
-            contains_object = true;
-        }
-        else
-        {
-            contains_object = false;
-        }
-    }
+  // If the variable doesn't exist, this NULL check will fail, continuing on.
+  if (ld_preload != NULL) {
+    // Check if the returned environment variable string contains the object.
+    contains_object = (strstr(ld_preload, object) != NULL);
+  }
 
-    // Return boolean
-    return contains_object;
+  // Return boolean
+  return contains_object;
 }
 
 // Determine if the specified file contains the passed object.
-bool file_contains_object(const char *object, const char *specified_file)
-{
-    bool contains_object = false;
+bool file_contains_object(const char *object, const char *specified_file) {
+  bool contains_object = false;
 
-    int fd;
-    struct stat file_info;
-    size_t size;;
+  int fd = 0;
+  struct stat file_info = {0};
+  size_t size = 0;
 
-    // Open the specified file into a file descriptor, read only.
-    // If the file doesn't open, return false.
-    if ((fd = open(specified_file, O_RDONLY)) >= 0)
-    {    
-        // Get the size of the specified file and dimension the mapped file buffer with it.
-        fstat(fd, &file_info);
-        size = file_info.st_size;
-        char mapped_file[size];
+  // Open the specified file into a file descriptor, read only.
+  // If the file doesn't open, return false.
+  if ((fd = open(specified_file, O_RDONLY)) >= 0) {
+    // Get the size of the specified file and dimension the mapped file buffer
+    // with it. When fstat(2) returns 0, it means the operation was successful.
+    if (fstat(fd, &file_info) == 0) {
+      size = file_info.st_size;
+      char mapped_file[size];
 
-        // Read the specified file into a buffer.
-        // Probably needs error handling.
-        read(fd,mapped_file,size);
-
+      // Read the specified file into a buffer.
+      // read(2) returns the number of bytes read when successful.
+      // If it returns 0, you've reached the end of the file.
+      if (read(fd, mapped_file, size) >= 0) {
         // Check if mapped file contains the object.
-        if (strstr(mapped_file,object) != NULL)
-        {
-            contains_object = true;
-        }
-        else
-        {
-            contains_object = false;
-        }
-        
-        // If the file descriptor is still open, close it.
-        if(fd)
-        {
-            close(fd);
-        }
+        contains_object = (strstr(mapped_file, object) != NULL);
+      }
     }
-    else
-    {
-        contains_object = false;
-    }
-    
-    // Return boolean
-    return contains_object;
+  }
+
+  // If the file descriptor is still open, close it.
+  if (fd) {
+    close(fd);
+  }
+
+  // Return boolean
+  return contains_object;
 }


### PR DESCRIPTION
## Summary of work:
- Apply clang-format to cleanup code layout.
- Add error handling for `fstat` and `read` calls.
- Clean up boolean assignments.
- Define constants for static strings.

## Notes
- I chose to use `clang-format` as it's relatively well accepted as a solid code formatter. It enforces things like line length and argument formatting. It can be configured to format differently but I figured something consistent initially was better than nothing.

## Testing:
- Ran unit tests as part of `make` on Ubuntu 18.04 LTS. One test failed due to missing test resource `/test/test_data/ld.so.preload`. **Did you forget to check this in @ForensicITGuy?**
